### PR TITLE
insertOnDuplicateUpdate: PDOException: SQLSTATE[HY093]: Invalid parameter number - thrown when passing literal as part of update clause

### DIFF
--- a/tests/unit/Adapters/PdoAdapterTest.php
+++ b/tests/unit/Adapters/PdoAdapterTest.php
@@ -444,6 +444,30 @@ class PdoAdapterTest extends BaseTest {
 
   } // insertOnDuplicateNoUpdate
 
+  /**
+   * @test
+   * @expectedException Behance\NBD\Dbal\Exceptions\InvalidQueryException
+   */
+  public function insertOnDuplicateIncorrectData() {
+
+    $adapter = $this->_getDisabledMock( PdoAdapter::class );
+
+    $adapter->insertOnDuplicateUpdate( $this->_table, $this->_insert_data, [ 'foo' ] );
+
+  } // insertOnDuplicateIncorrectData
+
+  /**
+   * @test
+   * @expectedException Behance\NBD\Dbal\Exceptions\InvalidQueryException
+   */
+  public function insertOnDuplicateIncorrectObject() {
+
+    $adapter = $this->_getDisabledMock( PdoAdapter::class );
+
+    $adapter->insertOnDuplicateUpdate( $this->_table, $this->_insert_data, [ 'foo' => new \stdClass ] );
+
+  } // insertOnDuplicateIncorrectObject
+
 
   /**
    * @test
@@ -537,7 +561,6 @@ class PdoAdapterTest extends BaseTest {
     $this->assertSame( 0, $adapter->insertOnDuplicateUpdate( $this->_table, $this->_insert_data, $this->_update_data ) );
 
   } // insertOnDuplicateUpdateSameData
-
 
   /**
    * @test


### PR DESCRIPTION
Fixes https://github.com/behance/nbd.php-dbal/issues/28

Just moved the `_prepPositionValuePairs` ( https://github.com/behance/nbd.php-dbal/blob/master/src/AdapterAbstract.php#L463 )  logic with some tweaks to adapt it to the `ON DUPLICATE` behavior.

@be-dmitry @ingluisjimenez @jimdelois 