### PR TITLE
ConnectionService: adding new table-specific connection mgmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ language: php
 php:
   - 5.6
   - 7.0
+  - 7.1
 
 matrix:
     allow_failures:
-      - php: 7.0
+      - php: 7.1
 
 env:
   - CFG_DB_HOST=127.0.0.1 CFG_DB_PORT=3306 CFG_DB_USER=travis CFG_DB_PASS= CFG_DB=dbal_test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM bryanlatten/docker-php:2.5.4
+FROM bryanlatten/docker-php:latest
 MAINTAINER Bryan Latten <latten@adobe.com>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ There are million of database adapters out there. But very few tick all (our ver
     - Read queries randomly choose a single replica connection per request, unless...
     - Choosing a master connection at any point in the lifecycle will always use it going forward
     - Loosely follows Doctrine's tenets @see http://www.doctrine-project.org/api/dbal/2.0/class-Doctrine.DBAL.Connections.MasterSlaveConnection.html
+    - [NEW] When connection retrievals include a table, master connection rules are segmented by table, with automatic fallback behavior when not specified.
 5. Out-of-the-box convenience support for CRUD operations, accessors, and fallback to raw SQL (works with other SQL generators as well).
     - Automatic conversion to prepared statements for convenience parameters
 7. Automatic retries for "mysql gone away" in long-running crons, workers, scripts

--- a/README.md
+++ b/README.md
@@ -133,6 +133,20 @@ Integration testing: leveraging Docker, using actual mysql container
 </tr>
 
 <tr>
+<td>queryTable</td>
+<td>$adapter->queryTable( ‘table’, "SELECT * FROM `table` WHERE id=? AND enabled=?", [ 12345, 0 ] );</td>
+<td>PDOStatement</td>
+<td>*PDOStatement is already executed</td>
+</tr>
+
+<tr>
+<td>queryTableMaster</td>
+<td>$adapter->queryMaster( ‘table’, "SELECT * FROM `table` WHERE id=:id AND enabled=:enabled, [ ':id' => 12345, ':enabled' => 0 ] );</td>
+<td>PDOStatement</td>
+<td>*PDOStatement is already executed, master connection used additional `table` queries</td>
+</tr>
+
+<tr>
 <td>query</td>
 <td>$adapter->query( "SELECT * FROM `table` WHERE id=? AND enabled=?", [ 12345, 0 ] );</td>
 <td>PDOStatement</td>
@@ -150,7 +164,7 @@ Integration testing: leveraging Docker, using actual mysql container
 <td>queryMaster</td>
 <td>$adapter->queryMaster( "SELECT * FROM `table` WHERE id=:id AND enabled=:enabled, [ ':id' => 12345, ':enabled' => 0 ] );</td>
 <td>PDOStatement</td>
-<td>*PDOStatement is already executed, connection is chosen to be master</td>
+<td>*PDOStatement is already executed, master connection is used for all future queries</td>
 </tr>
 
 <tr>

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Integration testing: leveraging Docker, using actual mysql container
 
 <tr>
 <td>queryTableMaster</td>
-<td>$adapter->queryMaster( ‘table’, "SELECT * FROM `table` WHERE id=:id AND enabled=:enabled, [ ':id' => 12345, ':enabled' => 0 ] );</td>
+<td>$adapter->queryTableMaster( ‘table’, "SELECT * FROM `table` WHERE id=:id AND enabled=:enabled, [ ':id' => 12345, ':enabled' => 0 ] );</td>
 <td>PDOStatement</td>
 <td>*PDOStatement is already executed, master connection used additional `table` queries</td>
 </tr>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ web:
   volumes:
    - ./:/app
   ports:
-  - '80'
+  - '8080'
   environment:
     CFG_APP_DEBUG: 1
     CFG_DB_HOST: db
@@ -15,7 +15,7 @@ web:
     CFG_DB: dbal_test
     FPM_BUSY_BUFFER: 16k
 db:
-  image: mysql:5.6.23
+  image: mysql:5.7
   ports:
   - '3306'
   environment:

--- a/src/AdapterInterface.php
+++ b/src/AdapterInterface.php
@@ -18,8 +18,8 @@ interface AdapterInterface {
   const EVENT_CONNECTION_DISCONNECT = 'db.connection.disconnect';
   const EVENT_CONNECTION_RECONNECT  = 'db.connection.reconnect';
 
-  const EVENT_QUERY_PRE_EXECUTE     = 'db.query.pre_execute';
-  const EVENT_QUERY_POST_EXECUTE    = 'db.query.post_execute';
+  const EVENT_QUERY_PRE_EXECUTE  = 'db.query.pre_execute';
+  const EVENT_QUERY_POST_EXECUTE = 'db.query.post_execute';
 
 
   /**
@@ -104,7 +104,7 @@ interface AdapterInterface {
 
 
   /**
-   * Prepares and executes a raw SQL statement
+   * Prepares and executes a raw SQL statement against master connection
    *
    * IMPORTANT: provided for the thinnest SQL compatibility possible,
    * default to helper methods to avoid writing raw SQL
@@ -131,11 +131,11 @@ interface AdapterInterface {
    *
    * @return PDOStatement  post-execution statement
    */
-  public function queryTable( $table, $sql, array $parameters = null );
+  public function queryTable( $table, $sql, array $parameters = null, $use_master = false );
 
 
   /**
-   * Prepares and executes a raw SQL statement, with explicit table usage
+   * Prepares and executes a raw SQL statement against master connection, with explicit table usage
    *
    *
    * IMPORTANT: provided for the thinnest SQL compatibility possible,
@@ -144,7 +144,6 @@ interface AdapterInterface {
    * @param string $table       explicitly call out the table in use
    * @param string $sql         can contain prepared statement placeholders ('?'' or ':key')
    * @param array  $parameters  format must match placeholders, if using ?, a flat array, otherwise key/value
-   * @param bool   $use_master  flags to use a master or replica connection (subject to connection rules)
    *
    * @return PDOStatement  post-execution statement
    */

--- a/src/AdapterInterface.php
+++ b/src/AdapterInterface.php
@@ -119,6 +119,38 @@ interface AdapterInterface {
 
 
   /**
+   * Prepares and executes a raw SQL statement, with explicit table usage
+   *
+   * IMPORTANT: provided for the thinnest SQL compatibility possible,
+   * default to helper methods to avoid writing raw SQL
+   *
+   * @param string $table       explicitly call out the table in use
+   * @param string $sql         can contain prepared statement placeholders ('?'' or ':key')
+   * @param array  $parameters  format must match placeholders, if using ?, a flat array, otherwise key/value
+   * @param bool   $use_master  flags to use a master or replica connection (subject to connection rules)
+   *
+   * @return PDOStatement  post-execution statement
+   */
+  public function queryTable( $table, $sql, array $parameters = null );
+
+
+  /**
+   * Prepares and executes a raw SQL statement, with explicit table usage
+   *
+   *
+   * IMPORTANT: provided for the thinnest SQL compatibility possible,
+   * default to helper methods to avoid writing raw SQL
+   *
+   * @param string $table       explicitly call out the table in use
+   * @param string $sql         can contain prepared statement placeholders ('?'' or ':key')
+   * @param array  $parameters  format must match placeholders, if using ?, a flat array, otherwise key/value
+   * @param bool   $use_master  flags to use a master or replica connection (subject to connection rules)
+   *
+   * @return PDOStatement  post-execution statement
+   */
+  public function queryTableMaster( $table, $sql, array $parameters = null );
+
+  /**
    * Provided only for backwards compatibility, protects a value being entered
    * into an SQL statement from command escaping/injection
    *

--- a/src/Adapters/PdoAdapter.php
+++ b/src/Adapters/PdoAdapter.php
@@ -383,9 +383,9 @@ class PdoAdapter extends AdapterAbstract {
 
     $sql = sprintf( "SELECT * FROM %s %s", $this->_quoteTable( $table ), $where_sql );
 
-    $parameters = ( empty( $where_prepared ) )
-                  ? null
-                  : $where_prepared;
+    $parameters = ( $where_prepared )
+                  ? $where_prepared
+                  : null;
 
     return [ $sql, $parameters ];
 
@@ -407,9 +407,9 @@ class PdoAdapter extends AdapterAbstract {
 
     $sql = sprintf( "SELECT %s FROM %s %s", $this->_quoteColumn( $field ), $this->_quoteTable( $table ), $where_sql );
 
-    $parameters = ( empty( $where_prepared ) )
-                  ? null
-                  : $where_prepared;
+    $parameters = ( $where_prepared )
+                  ? $where_prepared
+                  : null;
 
     return [ $sql, $parameters ];
 
@@ -421,7 +421,7 @@ class PdoAdapter extends AdapterAbstract {
    *
    * @param PDOStatement $statement
    *
-   * @return mixed
+   * @return mixed|null
    */
   public function extractOneValue( \Traversable $statement ) {
 

--- a/src/ConnectionService.php
+++ b/src/ConnectionService.php
@@ -46,7 +46,7 @@ class ConnectionService {
   private $_master_tables = [];
 
   /**
-   * Enabled to trigger fallback to table-inspecific connection behavior (legacy)
+   * Enabled to trigger fallback to table-agnostic connection behavior (legacy)
    *
    * @var bool
    */
@@ -72,7 +72,7 @@ class ConnectionService {
     if ( !$this->_master_flag ) {
 
       if ( $table ) {
-        // NOTE: using junky array index to store table name to prevent having to search a flat array before entering a value.
+        // NOTE: using less-than-ideal array index to store table name, prevents searching a flat array before appending
         $this->_master_tables[ $table ] = true;
       }
       else {

--- a/tests/lib/BaseTest.php
+++ b/tests/lib/BaseTest.php
@@ -5,6 +5,19 @@ namespace Behance\NBD\Dbal\Test;
 abstract class BaseTest extends \PHPUnit_Framework_TestCase {
 
   /**
+   * @return array
+   */
+  public function boolProvider() {
+
+    return [
+        [ true ],
+        [ false ]
+    ];
+
+  } // boolProvider
+
+
+  /**
    * @param string $class
    * @param array  $functions
    *

--- a/tests/lib/IntegrationTest.php
+++ b/tests/lib/IntegrationTest.php
@@ -77,6 +77,20 @@ abstract class IntegrationTest extends BaseTest {
 
   } // _getLiveAdapter
 
+  /**
+   * @return Behance\NBD\Dbal\AdapterInterface
+   */
+  protected function _getLiveReplicatedAdapter() {
+
+    $configs = [
+        'master'   => $this->_getEnvironmentConfig(),
+        'replicas' => [ $this->_getEnvironmentConfig() ],
+    ];
+
+    return Factory::create( $configs );
+
+  } // _getLiveReplicatedAdapter
+
 
   /**
    * @return array

--- a/tests/unit/AdapterAbstractTest.php
+++ b/tests/unit/AdapterAbstractTest.php
@@ -12,8 +12,12 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
  */
 class AdapterAbstractTest extends BaseTest {
 
-  private $_table = 'my_table';
-
+  private $_table  = 'abc';
+  private $_column = 'def';
+  private $_result = 10101010101;
+  private $_params = [ 678, 91011, 121314 ];
+  private $_sql    = "SELECT something FROM somebody";
+  private $_where_string = 'abc = 123';
 
   /**
    * @test
@@ -71,508 +75,115 @@ class AdapterAbstractTest extends BaseTest {
 
   /**
    * @test
-   * @dataProvider fetchOneResults
+   * @dataProvider boolProvider
    */
-  public function fetchOne( $results, $expected, $master ) {
+  public function getColAlias( $master ) {
 
-    $sql    = "SELECT value FROM anywhere";
-    $params = [ 1, 2, 3 ];
-    $target = $this->_setupFetch( $sql, $params, $results, $master );
+    $adapter = $this->_buildAdapter( null, [ 'getColumn' ] );
+    $adapter->expects( $this->once() )
+      ->method( 'getColumn' )
+      ->with( $this->_table, $this->_column, $this->_where_string, $master )
+      ->will( $this->returnValue( $this->_result ) );
 
-    $this->assertSame( $expected, $target->fetchOne( $sql, $params, $master ) );
+    $this->assertEquals( $this->_result, $adapter->getCol( $this->_table, $this->_column, $this->_where_string, $master ) );
 
-  } // fetchOne
+  } // getColAlias
 
 
   /**
    * @test
-   * @dataProvider fetchRowResults
+   * @dataProvider boolProvider
    */
-  public function fetchRow( $results, $expected, $master ) {
+  public function fetchColAlias( $master ) {
 
-    $sql    = "SELECT * FROM anywhere";
-    $params = [ 1, 2, 3 ];
-    $target = $this->_setupFetch( $sql, $params, $results, $master );
+    $adapter = $this->_buildAdapter( null, [ 'fetchColumn' ] );
+    $adapter->expects( $this->once() )
+      ->method( 'fetchColumn' )
+      ->with( $this->_sql, $this->_params, $master )
+      ->will( $this->returnValue( $this->_result ) );
 
-    $this->assertSame( $expected, $target->fetchRow( $sql, $params, $master ) );
+    $this->assertEquals( $this->_result, $adapter->fetchCol( $this->_sql, $this->_params, $master ) );
 
-  } // fetchRow
+  } // fetchColAlias
 
 
   /**
    * @test
-   * @dataProvider fetchColResults
+   * @dataProvider boolProvider
    */
-  public function fetchCol( $results, $expected, $master ) {
+  public function query( $master ) {
 
-    $sql    = "SELECT id FROM anywhere";
-    $params = [ 1, 2, 3 ];
-    $target = $this->_setupFetch( $sql, $params, $results, $master );
+    $adapter = $this->_buildAdapter( null, [ '_execute' ] );
+    $adapter->expects( $this->once() )
+      ->method( '_execute' )
+      ->with( null, $this->_sql, $this->_params, $master )
+      ->will( $this->returnValue( $this->_result ) );
 
-    $this->assertSame( $expected, $target->fetchCol( $sql, $params, $master ) );
+    $this->assertEquals( $this->_result, $adapter->query( $this->_sql, $this->_params, $master ) );
 
-  } // fetchCol
+  } // query
 
 
   /**
    * @test
-   * @dataProvider fetchAllResults
    */
-  public function fetchAll( $results, $expected, $master ) {
+  public function queryMaster() {
 
-    $sql    = "SELECT * FROM anywhere";
-    $params = [ 1, 2, 3 ];
-    $target = $this->_setupFetch( $sql, $params, $results, $master );
+    $adapter = $this->_buildAdapter( null, [ '_execute' ] );
+    $adapter->expects( $this->once() )
+      ->method( '_execute' )
+      ->with( null, $this->_sql, $this->_params, true )
+      ->will( $this->returnValue( $this->_result ) );
 
-    $this->assertSame( $expected, $target->fetchAll( $sql, $params, $master ) );
+    $this->assertEquals( $this->_result, $adapter->queryMaster( $this->_sql, $this->_params ) );
 
-  } // fetchAll
+  } // queryMaster
 
 
   /**
    * @test
-   * @dataProvider fetchAssocResults
+   * @dataProvider boolProvider
    */
-  public function fetchAssoc( $results, $expected, $master ) {
+  public function queryTable( $master ) {
 
-    $sql    = "SELECT * FROM anywhere";
-    $params = [ 1, 2, 3 ];
-    $target = $this->_setupFetch( $sql, $params, $results, $master );
+    $adapter = $this->_buildAdapter( null, [ '_execute' ] );
+    $adapter->expects( $this->once() )
+      ->method( '_execute' )
+      ->with( $this->_table, $this->_sql, $this->_params, $master )
+      ->will( $this->returnValue( $this->_result ) );
 
-    $this->assertSame( $expected, $target->fetchAssoc( $sql, $params, $master ) );
+    $this->assertEquals( $this->_result, $adapter->queryTable( $this->_table, $this->_sql, $this->_params, $master ) );
 
-  } // fetchAssoc
+  } // query
 
 
   /**
    * @test
-   * @dataProvider fetchPairsResults
    */
-  public function fetchPairs( $results, $expected, $master ) {
+  public function queryTableMaster() {
 
-    $sql    = "SELECT id, value FROM anywhere";
-    $params = [ 1, 2, 3 ];
-    $target = $this->_setupFetch( $sql, $params, $results, $master );
+    $adapter = $this->_buildAdapter( null, [ '_execute' ] );
+    $adapter->expects( $this->once() )
+      ->method( '_execute' )
+      ->with( $this->_table, $this->_sql, $this->_params, true )
+      ->will( $this->returnValue( $this->_result ) );
 
-    $this->assertSame( $expected, $target->fetchPairs( $sql, $params, $master ) );
+    $this->assertEquals( $this->_result, $adapter->queryTableMaster( $this->_table, $this->_sql, $this->_params ) );
 
-  } // fetchPairs
-
+  } // query
 
   /**
-   * @test
-   * @dataProvider fetchPairsBadResults
-   * @expectedException Behance\NBD\Dbal\Exceptions\QueryRequirementException
-   */
-  public function fetchPairsBad( $results, $master ) {
-
-    $sql    = "SELECT id, value FROM anywhere";
-    $params = [ 1, 2, 3 ];
-    $target = $this->_setupFetch( $sql, $params, $results, $master );
-
-    $target->fetchPairs( $sql, $params, $master );
-
-  } // fetchPairsBad
-
-
-  /**
-   * @return array
-   */
-  public function fetchOneResults() {
-
-    $value    = 123;
-    $one_col  = [ [ 'a' => $value ] ];
-    $two_col  = [ [ 'a' => $value, 'b' => 456 ] ];
-    $two_rows = [ [ 'abc' => $value ], [ 'def' => 456 ] ];
-    $zero     = [ [ 0 => 0 ] ];
-    $empty    = [ [] ];
-
-    return [
-        [ $one_col, $value, false ],
-        [ $one_col, $value, true ],
-        [ $two_col, $value, false ],
-        [ $two_col, $value, true ],
-        [ $two_rows, $value, false ],
-        [ $two_rows, $value, true ],
-        [ $zero, 0, false ],
-        [ $zero, 0, true ],
-        [ $empty, null, false ],
-        [ $empty, null, true ],
-    ];
-
-  } // fetchOneResults
-
-
-  /**
-   * @return array
-   */
-  public function fetchRowResults() {
-
-    $one_col  = [ 'abc' => 123 ];
-    $two_col  = [ 'abc' => 123, 'def' => 456 ];
-    $two_rows = [ $one_col, [ 'def' => 456 ] ];
-    $empty    = [ [] ];
-
-    return [
-        [ [ $one_col ], $one_col, false ],
-        [ [ $one_col ], $one_col, true ],
-        [ [ $two_col ], $two_col, false ],
-        [ [ $two_col ], $two_col, true ],
-        [ $two_rows, $one_col, false ],
-        [ $two_rows, $one_col, true ],
-        [ $empty, [], false ],
-        [ $empty, [], true ],
-    ];
-
-  } // fetchRowResults
-
-
-  /**
-   * @return array
-   */
-  public function fetchColResults() {
-
-    $value1   = 123;
-    $value2   = 789;
-    $values   = [ $value1, $value2 ];
-
-
-    $row1col1  = [ 'abc' => $value1 ];
-    $row1col2  = [ 'def' => 456 ];
-
-    $row2col1  = [ 'abc' => $value2 ];
-    $row2col2  = [ 'def' => 101112 ];
-
-    $row1  = array_merge( $row1col1, $row1col2 );
-    $row2  = array_merge( $row2col1, $row2col2 );
-
-    $two_rows = [ $row1, $row2 ];
-    $empty    = [ [] ];
-
-    return [
-        [ [ $row1col1 ], [ $value1 ], false ],
-        [ [ $row1col1 ], [ $value1 ], true ],
-        [ [ $row1 ], [ $value1 ], false ],
-        [ [ $row1 ], [ $value1 ], true ],
-        [ $two_rows, $values, false ],
-        [ $two_rows, $values, true ],
-        [ $empty, [], false ],
-        [ $empty, [], true ],
-    ];
-
-  } // fetchColResults
-
-
-  /**
-   * @return array
-   */
-  public function fetchAllResults() {
-
-    $value1   = 123;
-    $value2   = 789;
-
-    $row1col1  = [ 'abc' => $value1 ];
-    $row1col2  = [ 'def' => 456 ];
-
-    $row2col1  = [ 'abc' => $value2 ];
-    $row2col2  = [ 'def' => 101112 ];
-
-    $row1  = array_merge( $row1col1, $row1col2 );
-    $row2  = array_merge( $row2col1, $row2col2 );
-
-    $two_rows = [ $row1, $row2 ];
-    $empty    = [];
-
-    return [
-        [ [ $row1col1 ], [ $row1col1 ], false ],
-        [ [ $row1col1 ], [ $row1col1 ], true ],
-        [ [ $row1 ], [ $row1 ], false ],
-        [ [ $row1 ], [ $row1 ], true ],
-        [ $two_rows, $two_rows, false ],
-        [ $two_rows, $two_rows, true ],
-        [ $empty, $empty, false ],
-        [ $empty, $empty, true ],
-    ];
-
-  } // fetchAllResults
-
-
-  /**
-   * @return array
-   */
-  public function fetchAssocResults() {
-
-    $value1    = 123;
-    $value2    = 789;
-
-    $row1col1  = [ 'abc' => $value1 ];
-    $row1col2  = [ 'def' => 456 ];
-
-    $row2col1  = [ 'abc' => $value2 ];
-    $row2col2  = [ 'def' => 101112 ];
-
-    $row1      = array_merge( $row1col1, $row1col2 );
-    $row2      = array_merge( $row2col1, $row2col2 );
-    $two_rows  = [ $row1, $row2 ];
-
-    $empty     = [];
-
-    return [
-        [ [ $row1col1 ], [ $value1 => $row1col1 ], false ],
-        [ [ $row1col1 ], [ $value1 => $row1col1 ], true ],
-        [ [ $row1 ], [ $value1 => $row1 ], false ],
-        [ [ $row1 ], [ $value1 => $row1 ], true ],
-        [ $two_rows, [ $value1 => $row1, $value2 => $row2 ], false ],
-        [ $two_rows, [ $value1 => $row1, $value2 => $row2 ], true ],
-        [ $empty, $empty, false ],
-        [ $empty, $empty, true ],
-    ];
-
-  } // fetchAssocResults
-
-
-  /**
-   * @return array
-   */
-  public function fetchPairsResults() {
-
-    $value1 = 123;
-    $value2 = 456;
-    $value3 = 789;
-    $value4 = 101112;
-
-    $rows1 = [
-        [ 'id' => $value1, 'value' => $value2 ],
-    ];
-
-    $expected1 = [
-        $value1 => $value2,
-    ];
-
-    $rows2 = [
-        [ 'id' => $value1, 'value' => $value2 ],
-        [ 'id' => $value3, 'value' => $value4 ]
-    ];
-
-    $rows2b = [
-        [ 'id' => $value1, 'value' => $value2, 'extra' => 'abcdefg' ],
-        [ 'id' => $value3, 'value' => $value4, 'extra' => 'hijklmn' ]
-    ];
-
-    $expected2 = [
-        $value1 => $value2,
-        $value3 => $value4
-    ];
-
-    return [
-        [ $rows1,  $expected1, false ],
-        [ $rows1,  $expected1, true ],
-        [ $rows2,  $expected2, false ],
-        [ $rows2,  $expected2, true ],
-        [ $rows2b, $expected2, false ], // Ensure extra column is dropped
-        [ $rows2b, $expected2, true ],
-        [ [ [] ],  [], false ],
-        [ [ [] ],  [], true ],
-    ];
-
-  } // fetchPairsResults
-
-
-  /**
-   * @return array
-   */
-  public function fetchPairsBadResults() {
-
-    $rows1 = [
-        [ 'value' => 789 ],
-    ];
-
-
-    $rows2 = [
-        [ 'id' => 123 ],
-        [ 'id' => 456 ]
-    ];
-
-    return [
-        [ $rows1, false ],
-        [ $rows1, true ],
-        [ $rows2, false ],
-        [ $rows2, true ],
-    ];
-
-  } // fetchPairsBadResults
-
-
-  /**
-   * @test
-   * @dataProvider getQueryProvider
-   */
-  public function getQueries( $source, $destination, $where, $sql, $master ) {
-
-    $statement  = $this->_getDisabledMock( \PDOStatement::class );
-    $connection = $this->_getDisabledMock( ConnectionService::class );
-    $target     = $this->_getAbstractMock( AdapterAbstract::class, [ $destination ], [ $connection ] );
-
-    $target->expects( $this->once() )
-      ->method( $destination )
-      ->with( $this->stringContains( $sql ), array_values( $where ), $master )
-      ->will( $this->returnValue( $statement ) );
-
-    $result = $target->$source( $this->_table, $where, $master );
-    $this->assertInstanceOf( \PDOStatement::class, $result );
-
-  } // getQueries
-
-
-  /**
-   * Ensures the many conditions of WHERE building are correct
+   * @param Behance\NBD\Dbal\ConnectionService $connection
+   * @param array                              $functions
    *
-   * @test
-   * @dataProvider getRowWhereProvider
+   * @return Behance\NBD\Dbal\Adapters\PdoAdapter
    */
-  public function getRowWhere( $where, $expected_sql, $expected_params ) {
+  private function _buildAdapter( ConnectionService $connection = null, array $functions = [] ) {
 
-    $statement  = $this->_getDisabledMock( \PDOStatement::class );
-    $connection = $this->_getDisabledMock( ConnectionService::class );
-    $target     = $this->_getAbstractMock( AdapterAbstract::class, [ 'fetchRow' ], [ $connection ] );
+    $connection = $connection ?: $this->_getDisabledMock( ConnectionService::class );
 
-    $target->expects( $this->once() )
-      ->method( 'fetchRow' )
-      ->with( $this->stringContains( $expected_sql ), $expected_params )
-      ->will( $this->returnValue( $statement ) );
+    return $this->_getAbstractMock( AdapterAbstract::class, $functions, [ $connection ] );
 
-    $result = $target->getRow( $this->_table, $where );
-    $this->assertInstanceOf( \PDOStatement::class, $result );
-
-  } // getRowWhere
-
-
-  /**
-   * @return array
-   */
-  public function getRowWhereProvider() {
-
-    $base  = "SELECT * FROM `{$this->_table}`";
-
-    $value1 = 123;
-    $value2 = 456;
-
-    $single = [ 'abc' => $value1 ];
-    $double = [ 'abc' => $value1, 'def' => $value2 ];
-    $triple = [ 'abc' => $value1, 'def' => $value2, 'time' => new Sql( 'NOW()' ) ];
-
-    $string = "abc=123";
-    $object  = new Sql( $string );
-    $double_null = [ 'abc' => null, 'def' => $value2 ];
-
-    return [
-        [ '', $base, null ],
-        [ $single, "`abc` = ?", [ $value1 ] ],
-        [ $double, "`abc` = ? AND `def` = ?", [ $value1, $value2 ] ],
-        [ $double_null, "`abc` IS NULL AND `def` = ?", [ $value2 ] ],
-        [ $triple, "`abc` = ? AND `def` = ? AND `time` = NOW()", [ $value1, $value2 ] ],
-        [ $string, $string, null ],
-        [ $object, $string, null ],
-    ];
-
-  } // getRowWhereProvider
-
-
-  /**
-   * @test
-   * @dataProvider getColumnQueryProvider
-   */
-  public function getColumnQueries( $source, $destination, $column, $where, $sql, $master ) {
-
-    $statement  = $this->_getDisabledMock( \PDOStatement::class );
-    $connection = $this->_getDisabledMock( ConnectionService::class );
-    $target     = $this->_getAbstractMock( AdapterAbstract::class, [ $destination ], [ $connection ] );
-
-    $where_values = ( empty( $where ) )
-                    ? null
-                    : array_values( $where );
-
-    $target->expects( $this->once() )
-      ->method( $destination )
-      ->with( $this->stringContains( $sql ), $where_values, $master )
-      ->will( $this->returnValue( $statement ) );
-
-    $result = $target->$source( $this->_table, $column, $where, $master );
-    $this->assertInstanceOf( \PDOStatement::class, $result );
-
-  } // getColumnQueries
-
-
-  /**
-   * @return array
-   */
-  public function getQueryProvider() {
-
-    $sql   = "SELECT * FROM `{$this->_table}` WHERE `abc` = ? AND `def` = ?";
-    $where = [ 'abc' => 123, 'def' => 456 ];
-
-    return [
-        [ 'getRow', 'fetchRow', $where, $sql, false ],
-        [ 'getRow', 'fetchRow', $where, $sql, true ],
-        [ 'getAll', 'fetchAll', $where, $sql, false ],
-        [ 'getAll', 'fetchAll', $where, $sql, true ],
-        [ 'getAssoc', 'fetchAssoc', $where, $sql, false ],
-        [ 'getAssoc', 'fetchAssoc', $where, $sql, true ],
-    ];
-
-  } // getQueryProvider
-
-
-  /**
-   * @return array
-   */
-  public function getColumnQueryProvider() {
-
-    $column = 'enabled';
-    $sql    = "SELECT `{$column}` FROM `{$this->_table}` WHERE `abc` = ? AND `def` = ?";
-    $sql_nowhere = "SELECT `{$column}` FROM `{$this->_table}`";
-    $where  = [ 'abc' => 123, 'def' => 456 ];
-
-    return [
-        [ 'getOne', 'fetchOne', $column, $where, $sql, false ],
-        [ 'getOne', 'fetchOne', $column, $where, $sql, true ],
-        [ 'getCol', 'fetchColumn', $column, $where, $sql, false ],
-        [ 'getCol', 'fetchColumn', $column, $where, $sql, true ],
-        [ 'getColumn', 'fetchColumn', $column, $where, $sql, false ],
-        [ 'getColumn', 'fetchColumn', $column, $where, $sql, true ],
-        [ 'getColumn', 'fetchColumn', $column, '', $sql_nowhere, false ],
-        [ 'getColumn', 'fetchColumn', $column, '', $sql_nowhere, true ],
-    ];
-
-  } // getColumnQueryProvider
-
-
-  /**
-   * @param string $sql
-   * @param array  $params
-   * @param mixed  $results
-   * @param bool   $master
-   *
-   * @return mock
-   */
-  private function _setupFetch( $sql, array $params, $results, $master ) {
-
-    $connection = $this->_getDisabledMock( ConnectionService::class );
-    $target     = $this->_getAbstractMock( AdapterAbstract::class, [ 'query', 'queryMaster' ], [ $connection ] );
-
-    $adapter    = new PPDO();
-    $adapter->mock( $sql, $results );
-
-    $statement = $adapter->prepare( $sql );
-    $statement->execute( $params );
-
-    $target->expects( $this->once() )
-      ->method( 'query' )
-      ->with( $sql, $params, $master )
-      ->will( $this->returnValue( $statement ) );
-
-    return $target;
-
-  } // _setupFetch
+  } // _buildAdapter
 
 } // AdapterAbstractTest

--- a/tests/unit/QueryTest.php
+++ b/tests/unit/QueryTest.php
@@ -16,45 +16,79 @@ class QueryTest extends IntegrationTest {
                       `created_on` datetime DEFAULT NULL,
                       `modified_on` datetime DEFAULT NULL,
                       PRIMARY KEY (`id`)
+                    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
+      'secondary_table' => "CREATE TABLE `secondary_table` (
+                      `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+                      `enabled` tinyint(4) unsigned NOT NULL,
+                      `created_on` datetime DEFAULT NULL,
+                      `modified_on` datetime DEFAULT NULL,
+                      PRIMARY KEY (`id`)
                     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"
   ];
 
-  private $_table    = 'my_table';
+  private $_table = 'my_table';
+
+  private $_secondary_table = 'secondary_table';
+
+  private $_enabled     = 1;
+  private $_not_enabled = 0;
+  private $_now         = 'NOW()';
+
+  private $_adapter;
+
+  /**
+   * 1. Determines if test is currently running in integration mode, skips otherwise
+   * 2. If necessary creations
+   */
+  protected function setUp() {
+
+    parent::setUp();
+
+    $this->_adapter = $this->_getLiveAdapter();
+
+    $now  = 'NOW()';
+    $data = [
+        'enabled'     => $this->_enabled,
+        'created_on'  => new Sql( $now ),
+        'modified_on' => new Sql( $now )
+    ];
+
+    $this->_id = $this->_adapter->insert( $this->_table, $data );
+
+  } // setUp
 
   /**
    * @test
    */
   public function crudOperations() {
 
-    $adapter = $this->_getLiveAdapter();
-    $now     = 'NOW()';
-    $enabled = 1;
-    $not_enabled = 0;
-
-    $data    = [
-        'enabled'     => $enabled,
-        'created_on'  => new Sql( $now ),
-        'modified_on' => new Sql( $now )
-    ];
-
-    $id = $adapter->insert( $this->_table, $data );
+    $enabled = $this->_enabled;
+    $id      = $this->_id;
+    $adapter = $this->_adapter;
 
     $this->assertNotEmpty( $id );
 
     $inserted_row = $this->_fetchRow( $adapter, $id );
 
     $this->assertEquals( $id, $inserted_row['id'] ); // NOTE: lastInsertId is not type aware
-    $this->assertNotEquals( $now, $inserted_row['created_on'] );
-    $this->assertNotEquals( $now, $inserted_row['created_on'] );
+    $this->assertNotEquals( $this->_now, $inserted_row['created_on'] );
+    $this->assertNotEquals( $this->_now, $inserted_row['created_on'] );
     $this->assertSame( $enabled, $inserted_row['enabled'] ); // PDO automatically converts type with native prepare
 
-    $updated = $adapter->update( $this->_table, [ 'enabled' => $not_enabled ], [ 'id' => $id ] );
+    // Ensure fetch/get commands are formatted correctly
+    $this->assertEquals( $enabled, $adapter->getOne( $this->_table, 'enabled', [ 'id' => $id ] ) );
+    $this->assertEquals( [ $enabled ], $adapter->getColumn( $this->_table, 'enabled', [ 'id' => $id ] ) );
+    $this->assertEquals( $inserted_row, $adapter->getRow( $this->_table, [ 'id' => $id ] ) );
+    $this->assertEquals( [ $inserted_row ], $adapter->getAll( $this->_table, [ 'id' => $id ] ) );
+    $this->assertEquals( [ $id => $inserted_row ], $adapter->getAssoc( $this->_table, [ 'id' => $id ] ) );
+
+    $updated = $adapter->update( $this->_table, [ 'enabled' => $this->_not_enabled ], [ 'id' => $id ] );
 
     $this->assertSame( 1, $updated );
 
     $updated_row = $this->_fetchRow( $adapter, $id );
 
-    $this->assertSame( $not_enabled, $updated_row['enabled'] );
+    $this->assertSame( $this->_not_enabled, $updated_row['enabled'] );
 
     $deleted = $adapter->delete( $this->_table, [ 'id' => $id ] );
 
@@ -68,6 +102,44 @@ class QueryTest extends IntegrationTest {
 
 
   /**
+   * @test
+   */
+  public function tableConnectionSegmentation() {
+
+    $adapter    = $this->_getLiveReplicatedAdapter();
+    $connection = $adapter->getConnection();
+
+    $now  = 'NOW()';
+    $data = [
+        'enabled'     => 1,
+        'created_on'  => new Sql( $now ),
+        'modified_on' => new Sql( $now )
+    ];
+
+    $adapter->insert( $this->_table, $data );
+
+    $this->assertTrue( $connection->isUsingMaster() );
+    $this->assertTrue( $connection->isUsingMaster( $this->_table ) );
+    $this->assertFalse( $connection->isUsingMaster( $this->_secondary_table ) );
+
+    $adapter->closeConnection();
+
+    $this->assertFalse( $connection->isUsingMaster() );
+    $this->assertFalse( $connection->isUsingMaster( $this->_table ) );
+    $this->assertFalse( $connection->isUsingMaster( $this->_secondary_table ) );
+
+    $secondary_id = $adapter->insert( $this->_secondary_table, $data );
+
+    $this->assertNotEmpty( $secondary_id );
+
+    $this->assertTrue( $connection->isUsingMaster() );
+    $this->assertFalse( $connection->isUsingMaster( $this->_table ) );
+    $this->assertTrue( $connection->isUsingMaster( $this->_secondary_table ) );
+
+  } // tableConnectionSegmentation
+
+
+  /**
    * @param Behance\NBD\Dbal\AdapterInterface
    * @param int $id
    *
@@ -75,9 +147,10 @@ class QueryTest extends IntegrationTest {
    */
   protected function _fetchRow( AdapterInterface $adapter, $id ) {
 
-    $row = $adapter->getRow( $this->_table, [ 'id' => $id ] );
+    $row = $adapter->fetchRow( "SELECT * FROM {$this->_table} WHERE `id` = ?", [ $id ] );
 
     $this->assertInternalType( 'array', $row );
+    $this->assertEquals( $id, $row['id'] );
 
     return $row;
 


### PR DESCRIPTION
The existing contract guarantees DB replication lag safety, by enforcing that reads come from master *after* an existing write. But...this write-then-read policy is *only* valid on an individual table basis. A write to table `ABC` will not affect the replication lag for `DEF`.

- [x] moved PDO-specific commands out of AbstractAdapter into PdoAdapter, including tests
- [x] incorporate `get*` style commands: moved logic from fetch to `extract` fxs, used `queryTable` instead of `query`
- [x] event handler: pre-query has master usage intent, post-query has master *actual* usage
- [x] close connection reset
- [x] consolidated query generation
- do anything different on reconnect? `probably not`
- do anything different on transactions? `probably not`
- check into usage of quote() `probably not`

![screen shot 2017-03-21 at 3 28 53 pm](https://cloud.githubusercontent.com/assets/1202354/24166875/2b539838-0e4b-11e7-95e1-e2bcc2ed73af.png)