### PR TITLE
PDO Adapter: suppress warnings/errors

### DIFF
--- a/src/ConnectionService.php
+++ b/src/ConnectionService.php
@@ -261,7 +261,11 @@ class ConnectionService {
    */
   protected function _createConnection( $dsn, $user, $pass, $options ) {
 
-    return new \PDO( $dsn, $user, $pass, $options );
+   /**
+    * Add error/warning suppression to prevent double reporting
+    * @see https://bugs.php.net/bug.php?id=73878
+    */
+    return @new \PDO( $dsn, $user, $pass, $options );
 
   } // _createConnection
 

--- a/src/Events/QueryEvent.php
+++ b/src/Events/QueryEvent.php
@@ -37,27 +37,33 @@ class QueryEvent extends Event {
    */
   private $_exception;
 
+  /**
+   * @var bool
+   */
+  private $_is_retry;
 
 
   /**
-   * @param \PDOStatement|string $statement    either the prepared statement, or the SQL used to prepare
-   * @param array $parameters   query parameters sent to database
-   * @param bool  $use_master   whether or not master database is in use
+   * @param \PDOStatement|string           $statement    either the prepared statement, or the SQL used to prepare
+   * @param array                          $parameters   query parameters sent to database
+   * @param bool                           $use_master   whether or not master database is in use
    * @param Behance\NBD\Dbal\DbalException $exception
+   * @param bool                           $is_retry whether or not it is a retried query
    */
-  public function __construct( $statement, array $parameters = null, $use_master = false, DbalException $exception = null ) {
+  public function __construct( $statement, array $parameters = null, $use_master = false, DbalException $exception = null, $is_retry = false ) {
 
-    $this->_statement  = ( $statement instanceof \PDOStatement )
-                         ? $statement
-                         : null;
+    $this->_statement = ( $statement instanceof \PDOStatement )
+                        ? $statement
+                        : null;
 
-    $this->_query      = ( $this->_statement )
-                         ? $this->_statement->queryString
-                         : $statement;
+    $this->_query = ( $this->_statement )
+                    ? $this->_statement->queryString
+                    : $statement;
 
     $this->_parameters = $parameters;
     $this->_exception  = $exception;
     $this->_use_master = $use_master;
+    $this->_is_retry   = $is_retry;
 
   } // __construct
 
@@ -140,5 +146,14 @@ class QueryEvent extends Event {
     return $this->_exception;
 
   } // getException
+
+  /**
+   * @return boolean
+   */
+  public function isRetry() {
+
+    return $this->_is_retry;
+
+  } // isRetry
 
 } // QueryEvent


### PR DESCRIPTION
Due to PDO bug, warnings displayed will be displayed even when `PDO::ATTR_ERRMODE` is set to `PDO::ERRMODE_EXCEPTION`

https://bugs.php.net/bug.php?id=73878